### PR TITLE
`curried.merge_with` can accept a list of dicts.  Fixes #24

### DIFF
--- a/cytoolz/curried_exceptions.pyx
+++ b/cytoolz/curried_exceptions.pyx
@@ -1,4 +1,5 @@
 #cython: embedsignature=True
+from cpython.dict cimport PyDict_Check
 from .dicttoolz cimport c_merge_with
 
 __all__ = ['merge_with']
@@ -22,4 +23,7 @@ def merge_with(func, *dicts):
     """
     if len(dicts) == 0:
         raise TypeError
+    if len(dicts) == 1 and not PyDict_Check(dicts[0]):
+        dicts = dicts[0]
+
     return c_merge_with(func, dicts)

--- a/cytoolz/tests/test_curried.py
+++ b/cytoolz/tests/test_curried.py
@@ -16,6 +16,11 @@ def test_merge_with():
     assert merge_with(sum)({1: 1}, {1: 2}) == {1: 3}
 
 
+# XXX: backport to toolz
+def test_merge_with_list():
+    assert merge_with(sum, [{'a': 1}, {'a': 2}]) == {'a': 3}
+
+
 def test_sorted():
     assert sorted(key=second)([(1, 2), (2, 1)]) == [(2, 1), (1, 2)]
 


### PR DESCRIPTION
Regression test included.  Should be backported to toolz.
