### PR TITLE
Rename additional C bindings defined in `cytoolz.cpython`

### DIFF
--- a/cytoolz/cpython.pxd
+++ b/cytoolz/cpython.pxd
@@ -5,6 +5,6 @@ These differ from Cython's bindings in ``cpython``.
 from cpython.ref cimport PyObject
 
 cdef extern from "Python.h":
-    PyObject* PyIter_Next(object o)
-    PyObject* PyObject_Call(object callable_object, object args, object kw)
-    PyObject* PyObject_GetItem(object o, object key)
+    PyObject* PtrIter_Next "PyIter_Next"(object o)
+    PyObject* PtrObject_Call "PyObject_Call"(object callable_object, object args, object kw)
+    PyObject* PtrObject_GetItem "PyObject_GetItem"(object o, object key)

--- a/cytoolz/dicttoolz.pyx
+++ b/cytoolz/dicttoolz.pyx
@@ -7,7 +7,7 @@ from cpython.list cimport PyList_Append, PyList_New
 from cpython.ref cimport PyObject
 
 # Locally defined bindings that differ from `cython.cpython` bindings
-from .cpython cimport PyObject_GetItem
+from .cpython cimport PtrObject_GetItem
 
 
 __all__ = ['merge', 'merge_with', 'valmap', 'keymap', 'valfilter', 'keyfilter',
@@ -316,7 +316,7 @@ cpdef object get_in(object keys, object coll, object default=None, object no_def
     cdef object item
     cdef PyObject *obj
     for item in keys:
-        obj = PyObject_GetItem(coll, item)
+        obj = PtrObject_GetItem(coll, item)
         if obj is NULL:
             item = <object>PyErr_Occurred()
             if no_default or not PyErr_GivenExceptionMatches(item, _get_in_exceptions):

--- a/cytoolz/functoolz.pyx
+++ b/cytoolz/functoolz.pyx
@@ -9,7 +9,7 @@ from cpython.set cimport PyFrozenSet_New
 from cpython.tuple cimport PyTuple_Check, PyTuple_GET_SIZE
 
 # Locally defined bindings that differ from `cython.cpython` bindings
-from .cpython cimport PyObject_Call as CyObject_Call
+from .cpython cimport PtrObject_Call
 
 
 __all__ = ['identity', 'thread_first', 'thread_last', 'memoize', 'compose',
@@ -211,7 +211,7 @@ cdef class curry:
         if self.keywords is not None:
             PyDict_Merge(kwargs, self.keywords, False)
 
-        obj = CyObject_Call(self.func, args, kwargs)
+        obj = PtrObject_Call(self.func, args, kwargs)
         if obj is not NULL:
             val = <object>obj
             return val

--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -9,7 +9,7 @@ from cpython.set cimport PySet_Add, PySet_Contains
 from cpython.tuple cimport PyTuple_GetSlice, PyTuple_New, PyTuple_SET_ITEM
 
 # Locally defined bindings that differ from `cython.cpython` bindings
-from .cpython cimport PyIter_Next, PyObject_GetItem
+from .cpython cimport PtrIter_Next, PtrObject_GetItem
 
 from heapq import heapify, heappop, heapreplace
 from itertools import chain, islice
@@ -308,7 +308,7 @@ cdef class interleave:
             self.newiters = []
         val = <object>PyList_GET_ITEM(self.iters, self.i)
         self.i += 1
-        obj = PyIter_Next(val)
+        obj = PtrIter_Next(val)
 
         while obj is NULL:
             obj = PyErr_Occurred()
@@ -327,7 +327,7 @@ cdef class interleave:
                 self.newiters = []
             val = <object>PyList_GET_ITEM(self.iters, self.i)
             self.i += 1
-            obj = PyIter_Next(val)
+            obj = PtrIter_Next(val)
 
         PyList_Append(self.newiters, val)
         val = <object>obj
@@ -596,7 +596,7 @@ cpdef object get(object ind, object seq, object default=no_default):
 
         # List of indices with default
         for i, val in enumerate(ind):
-            obj = PyObject_GetItem(seq, val)
+            obj = PtrObject_GetItem(seq, val)
             if obj is NULL:
                 if not PyErr_ExceptionMatches(_get_list_exc):
                     raise <object>PyErr_Occurred()
@@ -609,7 +609,7 @@ cpdef object get(object ind, object seq, object default=no_default):
                 PyTuple_SET_ITEM(result, i, val)
         return result
 
-    obj = PyObject_GetItem(seq, ind)
+    obj = PtrObject_GetItem(seq, ind)
     if obj is NULL:
         val = <object>PyErr_Occurred()
         if default is no_default:
@@ -963,7 +963,7 @@ cdef class _pluck_index_default:
         cdef PyObject *obj
         cdef object val
         val = next(self.iterseqs)
-        obj = PyObject_GetItem(val, self.ind)
+        obj = PtrObject_GetItem(val, self.ind)
         if obj is NULL:
             if not PyErr_ExceptionMatches(_get_exceptions):
                 raise <object>PyErr_Occurred()
@@ -1011,7 +1011,7 @@ cdef class _pluck_list_default:
         seq = next(self.iterseqs)
         result = PyTuple_New(self.n)
         for i, val in enumerate(self.ind):
-            obj = PyObject_GetItem(seq, val)
+            obj = PtrObject_GetItem(seq, val)
             if obj is NULL:
                 if not PyErr_ExceptionMatches(_get_list_exc):
                     raise <object>PyErr_Occurred()


### PR DESCRIPTION
This differentiates the additional bindings with a common convention.  Currently, we only change bindings to return pointers instead of Python objects, and we change the name from "Py_" to "Ptr_".  I expect we will add more bindings in the future including passing pointers to functions.  In this case, the name should be something like "*_ptr".
