### PR TITLE
Simplify TravisCI script, which makes travis finish faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,12 @@ python:
     - "3.2"
     - "3.3"
 
-env:
-    - WITH_CYTHON=true
-    - WITH_CYTHON=false
-
 before_install:
     - pip install git+https://github.com/pytoolz/toolz.git
     - pip install cython
 
 install:
-    # *.c files aren't in the repo, so we must always create them
     - python setup.py build_ext --inplace --with-cython
-    - if [[ $WITH_CYTHON == 'false' ]]; then
-    -     rm cytoolz/*.so
-    -     python setup.py build_ext --inplace --without-cython
-    - fi
 
 # commands to run tests
 script:


### PR DESCRIPTION
I test installation with the C files that _I_ create using this branch:

https://github.com/eriknw/cytoolz/tree/check_my_c_files

Hence, we don't need to verify that cytoolz can be installed with only a C compiler for every commit.
