### PR TITLE
Support serialization of curry, compose, juxt, and complement objects.

### DIFF
--- a/cytoolz/functoolz.pxd
+++ b/cytoolz/functoolz.pxd
@@ -40,7 +40,7 @@ cdef class complement:
 
 
 cdef class _juxt_inner:
-    cdef tuple funcs
+    cdef public tuple funcs
 
 
 cdef object c_juxt(object funcs)

--- a/cytoolz/tests/test_serialization.py
+++ b/cytoolz/tests/test_serialization.py
@@ -1,0 +1,30 @@
+from cytoolz import *
+import pickle
+
+
+def test_compose():
+    f = compose(str, sum)
+    g = pickle.loads(pickle.dumps(f))
+    assert f((1, 2)) == g((1, 2))
+
+
+def test_curry():
+    f = curry(map)(str)
+    g = pickle.loads(pickle.dumps(f))
+    assert list(f((1, 2, 3))) == list(g((1, 2, 3)))
+
+
+def test_juxt():
+    f = juxt(str, int, bool)
+    g = pickle.loads(pickle.dumps(f))
+    assert f(1) == g(1)
+    assert f.funcs == g.funcs
+
+
+def test_complement():
+    f = complement(bool)
+    assert f(True) is False
+    assert f(False) is True
+    g = pickle.loads(pickle.dumps(f))
+    assert f(True) == g(True)
+    assert f(False) == g(False)


### PR DESCRIPTION
Addresses #32

Using `__reduce__` is weird.  Here is the documentation for it:

https://docs.python.org/2/library/pickle.html#pickling-and-unpickling-extension-types
