### PR TITLE
Add `cytoolz.utils.consume` to efficiently consume iterators.

### DIFF
--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -96,7 +96,6 @@ cdef class accumulate:
         return self.result
 
 
-
 cpdef dict groupby(object func, object seq):
     """
     Group a collection by a key function
@@ -1063,13 +1062,3 @@ cpdef object pluck(object ind, object seqs, object default=no_default):
     if default is no_default:
         return _pluck_index(ind, seqs)
     return _pluck_index_default(ind, seqs, default)
-
-
-# I find `_consume` convenient for benchmarking.  Perhaps this belongs
-# elsewhere, so it is private (leading underscore) and hidden away for now.
-
-cpdef object _consume(object seq):
-    """
-    Efficiently consume an iterable """
-    for _ in seq:
-        pass

--- a/cytoolz/tests/test_utils.py
+++ b/cytoolz/tests/test_utils.py
@@ -1,6 +1,15 @@
-from cytoolz.utils import raises
+from cytoolz.utils import raises, consume
 
 
 def test_raises():
     assert raises(ZeroDivisionError, lambda: 1 / 0)
     assert not raises(ZeroDivisionError, lambda: 1)
+
+
+def test_consume():
+    l = [1, 2, 3]
+    assert consume(l) is None
+    il = iter(l)
+    assert consume(il) is None
+    assert raises(StopIteration, lambda: next(il))
+    assert raises(TypeError, lambda: consume(1))

--- a/cytoolz/utils.pxd
+++ b/cytoolz/utils.pxd
@@ -1,0 +1,1 @@
+cpdef object consume(object seq)

--- a/cytoolz/utils.pyx
+++ b/cytoolz/utils.pyx
@@ -1,7 +1,11 @@
+#cython: embedsignature=True
 import doctest
 import inspect
 import os.path
 import cytoolz
+
+
+__all__ = ['raises', 'no_default', 'include_dirs', 'consume', 'module_doctest']
 
 
 def raises(err, lamda):
@@ -45,6 +49,13 @@ def include_dirs():
     return os.path.split(cytoolz.__path__[0])
 
 
+cpdef object consume(object seq):
+    """
+    Efficiently consume an iterable """
+    for _ in seq:
+        pass
+
+
 # The utilities below were obtained from:
 # https://github.com/cython/cython/wiki/FAQ
 # #how-can-i-run-doctests-in-cython-code-pyx-files
@@ -81,7 +92,7 @@ def _from_module(module, object):
         raise ValueError("object must be a class or function")
 
 
-def fix_module_doctest(module):
+def _fix_module_doctest(module):
     """
     Extract docstrings from cython functions, that would be skipped by doctest
     otherwise.
@@ -102,5 +113,5 @@ def module_doctest(m, *args, **kwargs):
 
     Return True on success, False on failure.
     """
-    fix_module_doctest(m)
+    _fix_module_doctest(m)
     return doctest.testmod(m, *args, **kwargs).failed == 0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ else:
 
 ext_modules = []
 for modname in ['dicttoolz', 'functoolz', 'itertoolz',
-                'curried_exceptions', 'recipes']:
+                'curried_exceptions', 'recipes', 'utils']:
     ext_modules.append(Extension('cytoolz.' + modname,
                                  ['cytoolz/' + modname + suffix]))
 


### PR DESCRIPTION
It was moved from `cytoolz.itertoolz._consume`.
`toolz` does not have `consume`.
