### PR TITLE
Define concat and concatv in itertoolz; don't use aliases.

### DIFF
--- a/cytoolz/__init__.pxd
+++ b/cytoolz/__init__.pxd
@@ -1,5 +1,5 @@
 from cytoolz.itertoolz cimport (
-    accumulate, c_merge_sorted, cons, count, drop, get, groupby, first,
+    accumulate, c_merge_sorted, concat, cons, count, drop, get, groupby, first,
     frequencies, interleave, interpose, isdistinct, isiterable, iterate,
     last, mapcat, nth, partition, partition_all, pluck, reduceby, remove,
     rest, second, sliding_window, take, take_nth, unique)

--- a/cytoolz/itertoolz.pxd
+++ b/cytoolz/itertoolz.pxd
@@ -81,6 +81,9 @@ cpdef object rest(object seq)
 cpdef object get(object ind, object seq, object default=*)
 
 
+cpdef object concat(object seqs)
+
+
 cpdef object cons(object el, object seq)
 
 

--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -24,10 +24,6 @@ __all__ = ['remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
            'sliding_window', 'partition', 'partition_all', 'count', 'pluck']
 
 
-concatv = chain
-concat = chain.from_iterable
-
-
 cpdef object identity(object x):
     return x
 
@@ -619,6 +615,41 @@ cpdef object get(object ind, object seq, object default=no_default):
             return default
         raise val
     return <object>obj
+
+
+_concat = chain.from_iterable
+
+
+cpdef object concat(object seqs):
+    """
+    Concatenate zero or more iterables, any of which may be infinite.
+
+    An infinite sequence will prevent the rest of the arguments from
+    being included.
+
+    We use chain.from_iterable rather than chain(*seqs) so that seqs
+    can be a generator.
+
+    >>> list(concat([[], [1], [2, 3]]))
+    [1, 2, 3]
+
+    See also:
+        itertools.chain.from_iterable  equivalent
+    """
+    return _concat(seqs)
+
+
+def concatv(*seqs):
+    """
+    Variadic version of concat
+
+    >>> list(concatv([], ["a"], ["b", "c"]))
+    ['a', 'b', 'c']
+
+    See also:
+        itertools.chain
+    """
+    return _concat(seqs)
 
 
 cpdef object mapcat(object func, object seqs):


### PR DESCRIPTION
Previously, we were cheating and doing the following:

``` python
concatv = chain
concat = chain.from_iterable
```

This is an artifact from when `cytoolz` was first being developed as proof-of-concept.  We should not be cheating or taking shortcuts like this.
