### PR TITLE
add conda.yaml and .binstar.yml files

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,14 @@
+package: cytoolz
+platform:
+  - linux-64
+  - linux-32
+  - osx-64
+engine:
+  - python=2
+  - python=3
+script:
+  - touch build.sh
+  - conda build .
+build_targets:
+  files: conda
+  channels: main

--- a/conda.yaml
+++ b/conda.yaml
@@ -1,0 +1,23 @@
+package:
+    name: cytoolz
+    version: "0.6.1"
+
+build:
+    number: {{environ.get('BINSTAR_BUILD', 1)}}
+    script: 
+      - cd $RECIPE_DIR
+      - $PYTHON setup.py install --with-cython
+
+requirements:
+    build:
+      - setuptools
+      - python
+      - cython
+      - toolz
+
+    run:
+      - python
+
+about:
+    home: http://toolz.readthedocs.org/
+    license: BSD


### PR DESCRIPTION
This provides hooks into an automated build process on binstar build.

We should be able to set it up so that we can do something like the following

```
conda install -c USERNAME cytoolz
```

Where USERNAME is something like `mrocklin` or `eriknw` or `pytoolz-dev`.  And it will download and install a binary on either Linux or OS-X, no C compiler required.
