### PR TITLE
reduceby and countby can accept an index or list of indices as the key

### DIFF
--- a/cytoolz/recipes.pxd
+++ b/cytoolz/recipes.pxd
@@ -1,4 +1,4 @@
-cpdef object countby(object func, object seq)
+cpdef object countby(object key, object seq)
 
 
 cdef class partitionby:

--- a/cytoolz/recipes.pyx
+++ b/cytoolz/recipes.pyx
@@ -1,6 +1,6 @@
 #cython: embedsignature=True
 from cpython.sequence cimport PySequence_Tuple
-from .itertoolz cimport frequencies
+from .itertoolz cimport frequencies, pluck
 
 from itertools import groupby
 from .compatibility import map
@@ -9,7 +9,7 @@ from .compatibility import map
 __all__ = ['countby', 'partitionby']
 
 
-cpdef object countby(object func, object seq):
+cpdef object countby(object key, object seq):
     """
     Count elements of a collection by a key function
 
@@ -23,7 +23,9 @@ cpdef object countby(object func, object seq):
     See Also:
         groupby
     """
-    return frequencies(map(func, seq))
+    if not callable(key):
+        return frequencies(pluck(key, seq))
+    return frequencies(map(key, seq))
 
 
 cdef class partitionby:

--- a/cytoolz/tests/test_itertoolz.py
+++ b/cytoolz/tests/test_itertoolz.py
@@ -225,6 +225,18 @@ def test_reduceby():
                     lambda acc, x: acc + x['cost'],
                     projects, 0) == {'CA': 1200000, 'IL': 2100000}
 
+    assert reduceby('state',
+                    lambda acc, x: acc + x['cost'],
+                    projects, 0) == {'CA': 1200000, 'IL': 2100000}
+
+    assert reduceby(['state'],
+                    lambda acc, x: acc + x['cost'],
+                    projects, 0) == {('CA',): 1200000, ('IL',): 2100000}
+
+    assert reduceby(['state', 'state'],
+                    lambda acc, x: acc + x['cost'],
+                    projects, 0) == {('CA', 'CA'): 1200000, ('IL', 'IL'): 2100000}
+
 
 def test_reduce_by_init():
     assert reduceby(iseven, add, [1, 2, 3, 4]) == {True: 2 + 4, False: 1 + 3}
@@ -348,8 +360,7 @@ def test_join_missing_element():
     names = [(1, 'one'), (2, 'two'), (3, 'three')]
     fruit = [('apple', 5), ('orange', 1)]
 
-    result = list(join(first, names, second, fruit))
-    result = set(starmap(add, result))
+    result = set(starmap(add, join(first, names, second, fruit)))
 
     expected = set([((1, 'one', 'orange', 1))])
 

--- a/cytoolz/tests/test_recipes.py
+++ b/cytoolz/tests/test_recipes.py
@@ -8,6 +8,9 @@ def iseven(x):
 def test_countby():
     assert countby(iseven, [1, 2, 3]) == {True: 1, False: 2}
     assert countby(len, ['cat', 'dog', 'mouse']) == {3: 2, 5: 1}
+    assert countby(0, ('ab', 'ac', 'bc')) == {'a': 2, 'b': 1}
+    assert countby([0], ('ab', 'ac', 'bc')) == {('a',): 2, ('b',): 1}
+    assert countby([0, 0], ('ab', 'ac', 'bc')) == {('a', 'a'): 2, ('b', 'b'): 1}
 
 
 def test_partitionby():


### PR DESCRIPTION
Lesson learned: even inline functions need to return `object` so exceptions can be properly raised.
