### PR TITLE
Faster join by using subclasses for each case (type of join and index keys)

### DIFF
--- a/cytoolz/itertoolz.pxd
+++ b/cytoolz/itertoolz.pxd
@@ -155,23 +155,22 @@ cpdef object join(object leftkey, object leftseq,
                   object right_default=*)
 
 cdef class _join:
-    cdef Py_ssize_t n
-    cdef object iterseq
-    cdef object leftkey
+    cdef dict d
+    cdef list matches
+    cdef set seen_keys
     cdef object leftseq
-    cdef object rightkey
     cdef object rightseq
-    cdef object matches
+    cdef object _rightkey
     cdef object right
-    cdef object key
-    cdef object d
-    cdef object d_items
-    cdef object seen_keys
-    cdef object is_rightseq_exhausted
     cdef object left_default
     cdef object right_default
-    cdef int i
     cdef object keys
+    cdef Py_ssize_t N
+    cdef Py_ssize_t i
+    cdef bint is_rightseq_exhausted
+
+    cdef object rightkey(self)
+
 
 cdef class _inner_join(_join):
     pass
@@ -183,4 +182,41 @@ cdef class _left_outer_join(_join):
     pass
 
 cdef class _outer_join(_join):
+    pass
+
+
+cdef class _inner_join_key(_inner_join):
+    pass
+
+cdef class _inner_join_index(_inner_join):
+    pass
+
+cdef class _inner_join_indices(_inner_join):
+    pass
+
+cdef class _right_outer_join_key(_right_outer_join):
+    pass
+
+cdef class _right_outer_join_index(_right_outer_join):
+    pass
+
+cdef class _right_outer_join_indices(_right_outer_join):
+    pass
+
+cdef class _left_outer_join_key(_left_outer_join):
+    pass
+
+cdef class _left_outer_join_index(_left_outer_join):
+    pass
+
+cdef class _left_outer_join_indices(_left_outer_join):
+    pass
+
+cdef class _outer_join_key(_outer_join):
+    pass
+
+cdef class _outer_join_index(_outer_join):
+    pass
+
+cdef class _outer_join_indices(_outer_join):
     pass


### PR DESCRIPTION
This is not the cleanest way to handle multiple key types (callable, list of indices, and a single index), and I don't want the current approach to set a precedence that will be used by other classes.  A cleaner approach would be to have a single `make_key` function with the following signature:

``` python
cdef inline object make_key(object rightkey, object item,
                            bint iscallable, bint islist)
```

I doubt that using `make_key` would significantly impact the performance.

But, the current implementation is written, works, and is fast, and I'm not one to reject code that meets those criteria.

I adapted the benchmarks from "toolz/bench/test_join.py" to `benchtoolz`.  "old" is the previous implementation, "new" is the current implementation, and "inline" is the new implementation with a bunch of copy-paste to perform the key calculation with no method call or indirection ("new" doesn't inline, but "cdef" functions are pretty fast; function pointers are used under the hood).

**Time:**

| **Bench** \ **Func** | ___inline__ | ___new__ | ___old__ |
| --: | :-: | :-: | :-: |
| **many_to_many_large** (`s`) | _1.02_ | **0.987** | 1.41 |
| **many_to_many_small** (`ms`) | _1.46_ | **1.45** | 1.87 |
| **many_to_many_small_index** (`ms`) | **0.91** | _0.914_ | 1.45 |
| **many_to_many_small_indices** (`ms`) | _1.33_ | **1.32** | 1.94 |
| **one_to_many** (`ms`) | **6.84** | _7.13_ | 10.8 |
| **one_to_one_tiny** (`us`) | **18.5** | _19_ | 24.5 |

**Relative time:**

| **Bench** \ **Func** | ___inline__ | ___new__ | ___old__ |
| --: | :-: | :-: | :-: |
| **many_to_many_large** | _1.03_ | **1** | 1.43 |
| **many_to_many_small** | _1.01_ | **1** | 1.3 |
| **many_to_many_small_index** | **1** | _1_ | 1.59 |
| **many_to_many_small_indices** | _1_ | **1** | 1.46 |
| **one_to_many** | **1** | _1.04_ | 1.59 |
| **one_to_one_tiny** | **1** | _1.02_ | 1.32 |
