### PR TITLE
Fix merge_sorted with key function (see #55).

### DIFF
--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -252,8 +252,7 @@ cdef class _merge_sorted_key:
                 item = self.pq[0]
                 self.shortcut = item[3]
                 return item[2]
-            retval = next(self.shortcut)
-            return self.key(retval)
+            return next(self.shortcut)
 
         item = self.pq[0]
         retval = item[2]

--- a/cytoolz/tests/test_itertoolz.py
+++ b/cytoolz/tests/test_itertoolz.py
@@ -75,6 +75,11 @@ def test_merge_sorted():
                                 key=lambda x: -ord(x))) == 'cccbbbaaa'
     assert list(merge_sorted([1], [2, 3, 4], key=identity)) == [1, 2, 3, 4]
 
+    data = [[(1, 2), (0, 4), (3, 6)], [(5, 3), (6, 5), (8, 8)],
+            [(9, 1), (9, 8), (9, 9)]]
+    assert list(merge_sorted(*data, key=lambda x: x[1])) == [
+        (9, 1), (1, 2), (5, 3), (0, 4), (6, 5), (3, 6), (8, 8), (9, 8), (9, 9)]
+
 
 def test_interleave():
     assert ''.join(interleave(('ABC', '123'))) == 'A1B2C3'


### PR DESCRIPTION
It was returning `key(item)` instead of `item` in a "shortcut" case.