### PR TITLE
Make running dev tests comparing toolz to cytoolz more strict.

### DIFF
--- a/cytoolz/tests/dev_skip_test.py
+++ b/cytoolz/tests/dev_skip_test.py
@@ -11,7 +11,11 @@ following conditions are true:
     - cytoolz is a release version
 """
 import cytoolz
-from nose.tools import nottest, istest
+try:
+    from nose.tools import nottest, istest
+except ImportError:
+    istest = lambda func: setattr(func, '__test__', True) or func
+    nottest = lambda func: setattr(func, '__test__', False) or func
 
 try:
     import toolz

--- a/cytoolz/tests/dev_skip_test.py
+++ b/cytoolz/tests/dev_skip_test.py
@@ -1,8 +1,30 @@
+"""
+Determine when dev tests should be skipped by regular users.
+
+Some tests are only intended to be tested during development right
+before performing a release.  These do not test core functionality
+of `cytoolz` and may be skipped.  These tests are only run if the
+following conditions are true:
+
+    - toolz is installed
+    - toolz is the correct version
+    - cytoolz is a release version
+"""
 import cytoolz
 from nose.tools import nottest, istest
 
+try:
+    import toolz
+    do_toolz_tests = True
+except ImportError:
+    do_toolz_tests = False
+
+if do_toolz_tests:
+    do_toolz_tests = cytoolz.__toolz_version__ == toolz.__version__
+    do_toolz_tests &= 'dev' not in cytoolz.__version__
+
 # Decorator used to skip tests for developmental versions of CyToolz
-if 'dev' in cytoolz.__version__:
-    dev_skip_test = nottest
-else:
+if do_toolz_tests:
     dev_skip_test = istest
+else:
+    dev_skip_test = nottest

--- a/cytoolz/tests/test_curried_toolzlike.py
+++ b/cytoolz/tests/test_curried_toolzlike.py
@@ -1,7 +1,5 @@
 import cytoolz
 import cytoolz.curried
-import toolz
-import toolz.curried
 import types
 from dev_skip_test import dev_skip_test
 
@@ -11,12 +9,15 @@ from dev_skip_test import dev_skip_test
 
 @dev_skip_test
 def test_toolzcurry_is_class():
+    import toolz
     assert isinstance(toolz.curry, type) is True
     assert isinstance(toolz.curry, types.FunctionType) is False
 
 
 @dev_skip_test
 def test_cytoolz_like_toolz():
+    import toolz
+    import toolz.curried
     for key, val in toolz.curried.__dict__.items():
         if isinstance(val, toolz.curry):
             if val.func is toolz.curry:  # XXX: Python 3.4 work-around!
@@ -29,6 +30,8 @@ def test_cytoolz_like_toolz():
 
 @dev_skip_test
 def test_toolz_like_cytoolz():
+    import toolz
+    import toolz.curried
     for key, val in cytoolz.curried.__dict__.items():
         if isinstance(val, cytoolz.curry):
             assert hasattr(toolz.curried, key), (

--- a/cytoolz/tests/test_docstrings.py
+++ b/cytoolz/tests/test_docstrings.py
@@ -1,6 +1,5 @@
 import difflib
 import cytoolz
-import toolz
 
 from cytoolz import curry, identity, keyfilter, valfilter, merge_with
 from cytoolz.utils import raises
@@ -33,6 +32,7 @@ def convertdoc(doc):
 
 @dev_skip_test
 def test_docstrings_uptodate():
+    import toolz
     differ = difflib.Differ()
 
     # only consider items created in both `toolz` and `cytoolz`

--- a/cytoolz/tests/test_embedded_sigs.py
+++ b/cytoolz/tests/test_embedded_sigs.py
@@ -1,6 +1,5 @@
 import inspect
 import cytoolz
-import toolz
 
 from types import BuiltinFunctionType
 from cytoolz import curry, identity, keyfilter, valfilter, merge_with
@@ -18,6 +17,7 @@ def test_class_sigs():
     """ Test that all ``cdef class`` extension types in ``cytoolz`` have
         correctly embedded the function signature as done in ``toolz``.
     """
+    import toolz
     # only consider items created in both `toolz` and `cytoolz`
     toolz_dict = valfilter(isfrommod('toolz'), toolz.__dict__)
     cytoolz_dict = valfilter(isfrommod('cytoolz'), cytoolz.__dict__)


### PR DESCRIPTION
Also, cytoolz may be tested when toolz is not installed.
Releases of cytoolz have no dependencies besides a C compiler.
Development versions of cytoolz required Cython.
Testing cytoolz requires `nose`.

Motivated by #57