### PR TITLE
fix pluck memory leak

### DIFF
--- a/cytoolz/dicttoolz.pyx
+++ b/cytoolz/dicttoolz.pyx
@@ -4,7 +4,7 @@ from cpython.dict cimport (PyDict_Check, PyDict_GetItem, PyDict_Merge,
                            PyDict_Update, PyDict_DelItem)
 from cpython.exc cimport PyErr_Clear, PyErr_GivenExceptionMatches, PyErr_Occurred
 from cpython.list cimport PyList_Append, PyList_New
-from cpython.ref cimport PyObject
+from cpython.ref cimport PyObject, Py_XDECREF
 
 # Locally defined bindings that differ from `cython.cpython` bindings
 from cytoolz.cpython cimport PtrObject_GetItem
@@ -407,5 +407,6 @@ cpdef object get_in(object keys, object coll, object default=None, object no_def
                 raise item
             PyErr_Clear()
             return default
+        Py_XDECREF(obj)
         coll = <object>obj
     return coll

--- a/cytoolz/functoolz.pyx
+++ b/cytoolz/functoolz.pyx
@@ -7,7 +7,7 @@ from cpython.dict cimport PyDict_Merge, PyDict_New
 from cpython.exc cimport PyErr_Clear, PyErr_ExceptionMatches, PyErr_Occurred
 from cpython.object cimport (PyCallable_Check, PyObject_Call, PyObject_CallObject,
                              PyObject_RichCompare, Py_EQ, Py_NE)
-from cpython.ref cimport PyObject
+from cpython.ref cimport PyObject, Py_DECREF
 from cpython.sequence cimport PySequence_Concat
 from cpython.set cimport PyFrozenSet_New
 from cpython.tuple cimport PyTuple_Check, PyTuple_GET_SIZE
@@ -240,6 +240,7 @@ cdef class curry:
         obj = PtrObject_Call(self.func, args, kwargs)
         if obj is not NULL:
             val = <object>obj
+            Py_DECREF(val)
             return val
 
         val = <object>PyErr_Occurred()

--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -3,7 +3,7 @@ from cpython.dict cimport PyDict_GetItem, PyDict_SetItem
 from cpython.exc cimport (PyErr_Clear, PyErr_ExceptionMatches,
                           PyErr_GivenExceptionMatches, PyErr_Occurred)
 from cpython.list cimport (PyList_Append, PyList_GET_ITEM, PyList_GET_SIZE)
-from cpython.ref cimport PyObject, Py_DECREF, Py_INCREF, Py_XDECREF
+from cpython.ref cimport PyObject, Py_INCREF, Py_XDECREF
 from cpython.sequence cimport PySequence_Check
 from cpython.set cimport PySet_Add, PySet_Contains
 from cpython.tuple cimport PyTuple_GetSlice, PyTuple_New, PyTuple_SET_ITEM

--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -661,7 +661,6 @@ cpdef object get(object ind, object seq, object default=no_default):
                 PyTuple_SET_ITEM(result, i, default)
             else:
                 val = <object>obj
-                Py_INCREF(val)
                 PyTuple_SET_ITEM(result, i, val)
         return result
 
@@ -674,6 +673,7 @@ cpdef object get(object ind, object seq, object default=no_default):
             PyErr_Clear()
             return default
         raise val
+    Py_XDECREF(obj)
     return <object>obj
 
 
@@ -1060,6 +1060,7 @@ cdef class _pluck_index_default:
                 raise <object>PyErr_Occurred()
             PyErr_Clear()
             return self.default
+        Py_XDECREF(obj)
         return <object>obj
 
 
@@ -1111,8 +1112,7 @@ cdef class _pluck_list_default:
                 PyTuple_SET_ITEM(result, i, self.default)
             else:
                 val = <object>obj
-                Py_INCREF(val)
-                PyTuple_SET_ITEM(result, i, val)  # TODO: redefine with "PyObject* val" and avoid cast
+                PyTuple_SET_ITEM(result, i, val)
         return result
 
 


### PR DESCRIPTION
This is one way to fix the memory leak in #63.

I actually don't know how, where, or why the reference count is being increased by one, which requires us to decrement it.  As such, I'm not entirely comfortable with the current solution or level of understanding.

I would like to investigate further.