### PR TITLE
ENH: Adds flip

### DIFF
--- a/cytoolz/functoolz.pyx
+++ b/cytoolz/functoolz.pyx
@@ -17,7 +17,7 @@ from cytoolz.cpython cimport PtrObject_Call
 
 
 __all__ = ['identity', 'thread_first', 'thread_last', 'memoize', 'compose',
-           'pipe', 'complement', 'juxt', 'do', 'curry', 'memoize']
+           'pipe', 'complement', 'juxt', 'do', 'curry', 'memoize', 'flip']
 
 
 cpdef object identity(object x):
@@ -580,3 +580,10 @@ cpdef object do(object func, object x):
     """
     func(x)
     return x
+
+
+cpdef object _flip(object f, object a, object b):
+    return PyObject_CallObject(f, (b, a))
+
+
+flip = curry(_flip)

--- a/cytoolz/tests/test_functoolz.py
+++ b/cytoolz/tests/test_functoolz.py
@@ -2,12 +2,11 @@ import platform
 
 
 from cytoolz.functoolz import (thread_first, thread_last, memoize, curry,
-                             compose, pipe, complement, do, juxt)
+                               compose, pipe, complement, do, juxt, flip)
 from cytoolz.functoolz import _num_required_args
 from operator import add, mul, itemgetter
 from cytoolz.utils import raises
 from functools import partial
-from cytoolz.compatibility import reduce, PY3
 
 
 def iseven(x):
@@ -484,3 +483,10 @@ def test_juxt_generator_input():
     juxtfunc = juxt(itemgetter(2*i) for i in range(5))
     assert juxtfunc(data) == (0, 2, 4, 6, 8)
     assert juxtfunc(data) == (0, 2, 4, 6, 8)
+
+
+def test_flip():
+    def f(a, b):
+        return a, b
+
+    assert flip(f, 'a', 'b') == ('b', 'a')

--- a/cytoolz/tests/test_none_safe.py
+++ b/cytoolz/tests/test_none_safe.py
@@ -140,6 +140,9 @@ def test_functoolz():
     assert thread_last(1, None) is None
     tested.append('thread_last')
 
+    assert flip(lambda a, b: (a, b))(None)(None) == (None, None)
+    tested.append('flip')
+
     s1 = set(tested)
     s2 = set(cytoolz.functoolz.__all__)
     assert s1 == s2, '%s not tested for being None-safe' % ', '.join(s2 - s1)


### PR DESCRIPTION
Ported the flip function over. Not much benifit from the cython but pulling PyObject_CallObject out of the ceval loop isn't the worst either.