### PR TITLE
Use `==` instead of `is` to check for no_default

### DIFF
--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -100,7 +100,7 @@ cdef class accumulate:
 
     def __next__(self):
         if self.result is self:
-            if self.initial is not no_default:
+            if self.initial != no_default:
                 self.result = self.initial
             else:
                 self.result = next(self.iter_seq)
@@ -651,7 +651,7 @@ cpdef object get(object ind, object seq, object default=no_default):
         i = PyList_GET_SIZE(ind)
         result = PyTuple_New(i)
         # List of indices, no default
-        if default is no_default:
+        if default == no_default:
             for i, val in enumerate(ind):
                 val = seq[val]
                 Py_INCREF(val)
@@ -677,7 +677,7 @@ cpdef object get(object ind, object seq, object default=no_default):
     if obj is NULL:
         val = <object>PyErr_Occurred()
         PyErr_Clear()
-        if default is no_default:
+        if default == no_default:
             raise val
         if PyErr_GivenExceptionMatches(val, _get_exceptions):
             return default
@@ -839,7 +839,7 @@ cpdef dict reduceby(object key, object binop, object seq, object init=no_default
     cdef dict d = {}
     cdef object item, keyval
     cdef Py_ssize_t i, N
-    cdef bint skip_init = init is no_default
+    cdef bint skip_init = init == no_default
     cdef bint call_init = callable(init)
     if callable(key):
         for item in seq:
@@ -1153,12 +1153,12 @@ cpdef object pluck(object ind, object seqs, object default=no_default):
         map
     """
     if isinstance(ind, list):
-        if default is not no_default:
+        if default != no_default:
             return _pluck_list_default(ind, seqs, default)
         if PyList_GET_SIZE(ind) < 10:
             return _pluck_list(ind, seqs)
         return map(itemgetter(*ind), seqs)
-    if default is no_default:
+    if default == no_default:
         return _pluck_index(ind, seqs)
     return _pluck_index_default(ind, seqs, default)
 

--- a/cytoolz/tests/test_itertoolz.py
+++ b/cytoolz/tests/test_itertoolz.py
@@ -3,6 +3,7 @@ from itertools import starmap
 from cytoolz.utils import raises
 from functools import partial
 from random import Random
+from pickle import dumps, loads
 from cytoolz.itertoolz import (remove, groupby, merge_sorted,
                              concat, concatv, interleave, unique,
                              isiterable, getter,
@@ -15,6 +16,10 @@ from cytoolz.itertoolz import (remove, groupby, merge_sorted,
                              diff, topk, peek, random_sample)
 from cytoolz.compatibility import range, filter
 from operator import add, mul
+
+
+# is comparison will fail between this and no_default
+no_default2 = loads(dumps('__no__default__'))
 
 
 def identity(x):
@@ -181,6 +186,7 @@ def test_get():
     assert raises(KeyError, lambda: get(10, {'a': 1}))
     assert raises(TypeError, lambda: get({}, [1, 2, 3]))
     assert raises(TypeError, lambda: get([1, 2, 3], 1, None))
+    assert raises(KeyError, lambda: get('foo', {}, default=no_default2))
 
 
 def test_mapcat():
@@ -248,6 +254,8 @@ def test_reduceby():
 
 def test_reduce_by_init():
     assert reduceby(iseven, add, [1, 2, 3, 4]) == {True: 2 + 4, False: 1 + 3}
+    assert reduceby(iseven, add, [1, 2, 3, 4], no_default2) == {True: 2 + 4,
+                                                                False: 1 + 3}
 
 
 def test_reduce_by_callable_default():
@@ -274,6 +282,7 @@ def test_accumulate():
 
     start = object()
     assert list(accumulate(binop, [], start)) == [start]
+    assert list(accumulate(add, [1, 2, 3], no_default2)) == [1, 3, 6]
 
 
 def test_accumulate_works_on_consumable_iterables():
@@ -328,6 +337,9 @@ def test_pluck():
     assert raises(IndexError, lambda: list(pluck(1, [[0]])))
     assert raises(KeyError, lambda: list(pluck('name', [{'id': 1}])))
 
+    assert list(pluck(0, [[0, 1], [2, 3], [4, 5]], no_default2)) == [0, 2, 4]
+    assert raises(IndexError, lambda: list(pluck(1, [[0]], no_default2)))
+
 
 def test_join():
     names = [(1, 'one'), (2, 'two'), (3, 'three')]
@@ -343,6 +355,11 @@ def test_join():
                     ((2, 'two', 'banana', 2)),
                     ((2, 'two', 'coconut', 2))])
 
+    assert result == expected
+
+    result = set(starmap(add, join(first, names, second, fruit,
+                                   left_default=no_default2,
+                                   right_default=no_default2)))
     assert result == expected
 
 

--- a/cytoolz/utils.pyx
+++ b/cytoolz/utils.pyx
@@ -19,7 +19,7 @@ try:
     # Attempt to get the no_default sentinel object from toolz
     from toolz.utils import no_default
 except ImportError:
-    no_default = '__no_default__'
+    no_default = '__no__default__'
 
 
 def include_dirs():


### PR DESCRIPTION
Previously, `is` was used to check if keywords were equivalent to
`no_default`. This failed if the default string was serialized using
pickle, as then the reconstructed string isn't the same object. This PR
fixes that by replacing all is checks for `no_default` with `==`.

Also modified the `no_default` string to be equivalent to that in `toolz`.

See https://github.com/pytoolz/toolz/pull/310 for equivalent PR.