### PR TITLE
Fix bug in pluck with default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,14 @@ clean:
 
 curried:
 	$(PYTHON) etc/generate_curried.py > cytoolz/curried/__init__.py
+
+copytests:
+	for f in ../toolz/toolz/tests/test*py; \
+	do \
+		if [[ $$f == *test_utils* ]]; then continue ; fi;  \
+		newf=`echo $$f | sed 's/...toolz.toolz/cytoolz/g'`; \
+		sed -e 's/toolz/cytoolz/g' -e 's/itercytoolz/itertoolz/' \
+			-e 's/dictcytoolz/dicttoolz/g' -e 's/funccytoolz/functoolz/g' \
+			$$f > $$newf; \
+		echo $$f $$newf; \
+	done

--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -1054,6 +1054,7 @@ cdef class _pluck_index_default:
     def __cinit__(self, object ind, object seqs, object default):
         self.ind = ind
         self.iterseqs = iter(seqs)
+        self.default = default
 
     def __iter__(self):
         return self

--- a/cytoolz/tests/test_itertoolz.py
+++ b/cytoolz/tests/test_itertoolz.py
@@ -328,11 +328,10 @@ def test_pluck():
 
     data = [{'id': 1, 'name': 'cheese'}, {'id': 2, 'name': 'pies', 'price': 1}]
     assert list(pluck('id', data)) == [1, 2]
-    assert list(pluck('price', data, None)) == [None, 1]
+    assert list(pluck('price', data, 0)) == [0, 1]
     assert list(pluck(['id', 'name'], data)) == [(1, 'cheese'), (2, 'pies')]
     assert list(pluck(['name'], data)) == [('cheese',), ('pies',)]
-    assert list(pluck(['price', 'other'], data, None)) == [(None, None),
-                                                           (1, None)]
+    assert list(pluck(['price', 'other'], data, 0)) == [(0, 0), (1, 0)]
 
     assert raises(IndexError, lambda: list(pluck(1, [[0]])))
     assert raises(KeyError, lambda: list(pluck('name', [{'id': 1}])))


### PR DESCRIPTION
The non-list version of pluck with default failed to actually set
`default` as an attribute of the object, resulting in all accesses being
None. This passed the tests, since the only time a default was used was
when it was None.

Fixes https://github.com/dask/dask/issues/1603.