### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ projects developed in Cython.  Since ``toolz`` is able to process very
 large (potentially infinite) data sets, the performance increase gained by
 using ``cytoolz`` can be significant.
 
-See the PyToolz documentation at http://toolz.readthedocs.org and the full
-`API Documentation <http://toolz.readthedocs.org/en/latest/api.html>`__
+See the PyToolz documentation at https://toolz.readthedocs.io and the full
+`API Documentation <https://toolz.readthedocs.io/en/latest/api.html>`__
 for more details.
 
 LICENSE

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,5 +28,5 @@ test:
       - py.test -x --doctest-modules --pyargs cytoolz
 
 about:
-    home: http://toolz.readthedocs.org/
+    home: https://toolz.readthedocs.io/
     license: BSD

--- a/cytoolz/functoolz.pyx
+++ b/cytoolz/functoolz.pyx
@@ -164,7 +164,7 @@ cdef class curry:
 
     See Also:
         cytoolz.curried - namespace of curried functions
-                        http://toolz.readthedocs.org/en/latest/curry.html
+                        https://toolz.readthedocs.io/en/latest/curry.html
     """
 
     def __cinit__(self, *args, **kwargs):


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
