### PR TITLE
Package the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
+include LICENSE.txt
+
 include cytoolz/tests/*.py


### PR DESCRIPTION
Closes https://github.com/pytoolz/cytoolz/issues/75

Includes the license file in the `sdist` to aid in complying with the terms of BSD 3-Clause license.