### PR TITLE
Fix issue #87: Compile with Cython >= 0.25

### DIFF
--- a/requirements_devel.txt
+++ b/requirements_devel.txt
@@ -1,3 +1,3 @@
-cython>=0.17
+cython>=0.21
 nose
 -e git+https://github.com/pytoolz/toolz.git

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,7 @@ for modname in ['dicttoolz', 'functoolz', 'itertoolz', 'recipes', 'utils']:
                                  ['cytoolz/' + modname + suffix]))
 
 if use_cython:
-    from Cython.Compiler.Options import directive_defaults
-    directive_defaults['embedsignature'] = True
-    directive_defaults['binding'] = True
-    ext_modules = cythonize(ext_modules)
+    ext_modules = cythonize(ext_modules, compiler_directives={'embedsignature': True, 'binding': True})
 
 setup(
     name='cytoolz',


### PR DESCRIPTION
I've switched setup.py to use compiler_directives option to cythonize instead of modifying default_directives, so building with Cython before 0.25 and after will both work.

Before making the change I also went back in Cython versions to see the earliest version that would be supported, and this patch doesn't change that. I've update minimum supported Cython build version in requirements_devel.txt, versions 0.17 (previous minimum) to less than 0.21 all failed compilation for various reasons unrelated to directive_defaults.