### PR TITLE
Update `cytoolz` to the latest dev version of `toolz`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ copytests:
 	for f in ../toolz/toolz/tests/test*py; \
 	do \
 		if [[ $$f == *test_utils* ]]; then continue ; fi;  \
+		if [[ $$f == *test_curried_doctests* ]]; then continue ; fi;  \
+		if [[ $$f == *test_tlz* ]]; then continue ; fi;  \
 		newf=`echo $$f | sed 's/...toolz.toolz/cytoolz/g'`; \
 		sed -e 's/toolz/cytoolz/g' -e 's/itercytoolz/itertoolz/' \
 			-e 's/dictcytoolz/dicttoolz/g' -e 's/funccytoolz/functoolz/g' \

--- a/cytoolz/__init__.pxd
+++ b/cytoolz/__init__.pxd
@@ -3,7 +3,7 @@ from cytoolz.itertoolz cimport (
     frequencies, interleave, interpose, isdistinct, isiterable, iterate,
     last, mapcat, nth, partition, partition_all, pluck, reduceby, remove,
     rest, second, sliding_window, take, tail, take_nth, unique, join,
-    c_diff, topk, peek, random_sample)
+    c_diff, topk, peek, random_sample, concat)
 
 
 from cytoolz.functoolz cimport (

--- a/cytoolz/__init__.pxd
+++ b/cytoolz/__init__.pxd
@@ -7,8 +7,8 @@ from cytoolz.itertoolz cimport (
 
 
 from cytoolz.functoolz cimport (
-    c_compose, c_juxt, c_memoize, c_pipe, c_thread_first, c_thread_last,
-    complement, curry, do, identity, excepts, c_flip)
+    c_compose, c_juxt, memoize, c_pipe, c_thread_first, c_thread_last,
+    complement, curry, do, identity, excepts, flip)
 
 
 from cytoolz.dicttoolz cimport (

--- a/cytoolz/__init__.py
+++ b/cytoolz/__init__.py
@@ -17,6 +17,10 @@ sorted = sorted
 # Aliases
 comp = compose
 
+# Always-curried functions
+flip = functoolz.flip = curry(functoolz.flip)
+memoize = functoolz.memoize = curry(functoolz.memoize)
+
 functoolz._sigs.update_signature_registry()
 
 from ._version import __version__, __toolz_version__

--- a/cytoolz/_signatures.py
+++ b/cytoolz/_signatures.py
@@ -36,10 +36,6 @@ cytoolz_info['cytoolz.dicttoolz'] = dict(
 cytoolz_info['cytoolz.functoolz'] = dict(
     Compose=[
         lambda *funcs: None],
-    c_flip=[
-        lambda func, a, b: None],
-    c_memoize=[
-        lambda func, cache=None, key=None: None],
     complement=[
         lambda func: None],
     compose=[
@@ -50,12 +46,14 @@ cytoolz_info['cytoolz.functoolz'] = dict(
         lambda func, x: None],
     excepts=[
         lambda exc, func, handler=None: None],
+    flip=[  # XXX: these are optional, but not keywords!
+        lambda func=None, a=None, b=None: None],
     identity=[
         lambda x: None],
     juxt=[
         lambda *funcs: None],
-    memoize=[
-        lambda func, cache=None, key=None: None],
+    memoize=[  # XXX: func is optional, but not a keyword!
+        lambda func=None, cache=None, key=None: None],
     pipe=[
         lambda data, *funcs: None],
     return_none=[
@@ -90,7 +88,7 @@ cytoolz_info['cytoolz.itertoolz'] = dict(
     identity=[
         lambda x: None],
     interleave=[
-        lambda seqs, pass_exceptions=(): None],
+        lambda seqs: None],
     interpose=[
         lambda el, seq: None],
     isdistinct=[

--- a/cytoolz/_signatures.py
+++ b/cytoolz/_signatures.py
@@ -48,12 +48,16 @@ cytoolz_info['cytoolz.functoolz'] = dict(
         lambda exc, func, handler=None: None],
     flip=[  # XXX: these are optional, but not keywords!
         lambda func=None, a=None, b=None: None],
+    _flip=[
+        lambda func, a, b: None],
     identity=[
         lambda x: None],
     juxt=[
         lambda *funcs: None],
     memoize=[  # XXX: func is optional, but not a keyword!
         lambda func=None, cache=None, key=None: None],
+    _memoize=[
+        lambda func, cache=None, key=None: None],
     pipe=[
         lambda data, *funcs: None],
     return_none=[

--- a/cytoolz/_signatures.py
+++ b/cytoolz/_signatures.py
@@ -71,6 +71,10 @@ cytoolz_info['cytoolz.functoolz'] = dict(
 cytoolz_info['cytoolz.itertoolz'] = dict(
     accumulate=[
         lambda binop, seq, initial='__no__default__': None],
+    concat=[
+        lambda seqs: None],
+    concatv=[
+        lambda *seqs: None],
     cons=[
         lambda el, seq: None],
     count=[

--- a/cytoolz/compatibility.py
+++ b/cytoolz/compatibility.py
@@ -5,7 +5,7 @@ PY33 = sys.version_info[0] == 3 and sys.version_info[1] == 3
 PY34 = sys.version_info[0] == 3 and sys.version_info[1] == 4
 
 __all__ = ['PY3', 'map', 'filter', 'range', 'zip', 'reduce', 'zip_longest',
-           'iteritems', 'iterkeys', 'itervalues']
+           'iteritems', 'iterkeys', 'itervalues', 'import_module']
 
 if PY3:
     map = map
@@ -27,3 +27,10 @@ else:
     iteritems = operator.methodcaller('iteritems')
     iterkeys = operator.methodcaller('iterkeys')
     itervalues = operator.methodcaller('itervalues')
+
+try:
+    from importlib import import_module
+except ImportError:
+    def import_module(name):
+        __import__(name)
+        return sys.modules[name]

--- a/cytoolz/curried/__init__.py
+++ b/cytoolz/curried/__init__.py
@@ -48,7 +48,6 @@ _curry_set = frozenset([
     cytoolz.get,
     cytoolz.get_in,
     cytoolz.groupby,
-    cytoolz.interleave,
     cytoolz.interpose,
     cytoolz.itemfilter,
     cytoolz.itemmap,

--- a/cytoolz/curried/exceptions.py
+++ b/cytoolz/curried/exceptions.py
@@ -1,5 +1,4 @@
 import cytoolz
-#from cytoolz import curry, merge as _merge, merge_with as _merge_with
 
 __all__ = ['merge', 'merge_with']
 

--- a/cytoolz/functoolz.pxd
+++ b/cytoolz/functoolz.pxd
@@ -16,7 +16,7 @@ cdef class curry:
     cdef public object __doc__
     cdef public object __name__
 
-cdef class c_memoize:
+cdef class memoize:
     cdef object func
     cdef object cache
     cdef object key
@@ -49,7 +49,7 @@ cdef object c_juxt(object funcs)
 cpdef object do(object func, object x)
 
 
-cpdef object c_flip(object func, object a, object b)
+cpdef object flip(object func, object a, object b)
 
 
 cpdef object return_none(object exc)

--- a/cytoolz/functoolz.pyx
+++ b/cytoolz/functoolz.pyx
@@ -446,6 +446,9 @@ cdef class memoize:
         return curry(self, instance)
 
 
+_memoize = memoize  # uncurried
+
+
 cdef class Compose:
     """ Compose(self, *funcs)
 
@@ -678,6 +681,9 @@ cpdef object flip(object func, object a, object b):
     [1, 2, 3]
     """
     return PyObject_CallObject(func, (b, a))
+
+
+_flip = flip  # uncurried
 
 
 cpdef object return_none(object exc):

--- a/cytoolz/functoolz.pyx
+++ b/cytoolz/functoolz.pyx
@@ -4,7 +4,7 @@ from functools import partial
 from operator import attrgetter
 from textwrap import dedent
 from cytoolz.utils import no_default
-from cytoolz.compatibility import PY3, PY34, filter as ifilter, map as imap, reduce
+from cytoolz.compatibility import PY3, PY34, filter as ifilter, map as imap, reduce, import_module
 import cytoolz._signatures as _sigs
 
 from toolz.functoolz import (InstanceProperty, instanceproperty, is_arity,
@@ -233,6 +233,15 @@ cdef class curry:
                 return type(self)(self.func, *args, **kwargs)
             raise
 
+    def _should_curry(self, args, kwargs, exc=None):
+        if PyTuple_GET_SIZE(args) == 0:
+            args = self.args
+        elif PyTuple_GET_SIZE(self.args) != 0:
+            args = PySequence_Concat(self.args, args)
+        if self.keywords is not None:
+            PyDict_Merge(kwargs, self.keywords, False)
+        return self._should_curry_internal(args, kwargs)
+
     def _should_curry_internal(self, args, kwargs, exc=None):
         func = self.func
 
@@ -281,12 +290,6 @@ cdef class curry:
             return self
         return type(self)(self, instance)
 
-    def __reduce__(self):
-        return (type(self), (self.func,), (self.args, self.keywords))
-
-    def __setstate__(self, state):
-        self.args, self.keywords = state
-
     property __signature__:
         def __get__(self):
             sig = inspect.signature(self.func)
@@ -325,8 +328,33 @@ cdef class curry:
 
             return sig.replace(parameters=newparams)
 
+    def __reduce__(self):
+        func = self.func
+        modname = getattr(func, '__module__', None)
+        funcname = getattr(func, '__name__', None)
+        if modname and funcname:
+            module = import_module(modname)
+            obj = getattr(module, funcname, None)
+            if obj is self:
+                return funcname
+            elif isinstance(obj, curry) and obj.func is func:
+                func = '%s.%s' % (modname, funcname)
 
-cdef class c_memoize:
+        state = (type(self), func, self.args, self.keywords)
+        return (_restore_curry, state)
+
+
+cpdef object _restore_curry(cls, func, args, kwargs):
+    if isinstance(func, str):
+        modname, funcname = func.rsplit('.', 1)
+        module = import_module(modname)
+        func = getattr(module, funcname).func
+    obj = cls(func, *args, **(kwargs or {}))
+    return obj
+
+
+
+cdef class memoize:
     """ memoize(func, cache=None, key=None)
 
     Cache a function's result for speedy future evaluation
@@ -416,9 +444,6 @@ cdef class c_memoize:
         if instance is None:
             return self
         return curry(self, instance)
-
-
-memoize = curry(c_memoize)
 
 
 cdef class Compose:
@@ -628,22 +653,20 @@ cpdef object do(object func, object x):
     return x
 
 
-@cython.embedsignature(False)
-cpdef object c_flip(object func, object a, object b):
-    """ flip(func, a, b)
-
+cpdef object flip(object func, object a, object b):
+    """
     Call the function call with the arguments flipped
 
     This function is curried.
 
     >>> def div(a, b):
-    ...     return a / b
+    ...     return a // b
     ...
-    >>> flip(div, 2, 1)
-    0.5
+    >>> flip(div, 2, 6)
+    3
     >>> div_by_two = flip(div, 2)
     >>> div_by_two(4)
-    2.0
+    2
 
     This is particularly useful for built in functions and functions defined
     in C extensions that accept positional only arguments. For example:
@@ -655,9 +678,6 @@ cpdef object c_flip(object func, object a, object b):
     [1, 2, 3]
     """
     return PyObject_CallObject(func, (b, a))
-
-
-flip = curry(c_flip)
 
 
 cpdef object return_none(object exc):

--- a/cytoolz/itertoolz.pxd
+++ b/cytoolz/itertoolz.pxd
@@ -37,7 +37,6 @@ cdef object c_merge_sorted(object seqs, object key=*)
 cdef class interleave:
     cdef list iters
     cdef list newiters
-    cdef tuple pass_exceptions
     cdef Py_ssize_t i
     cdef Py_ssize_t n
 

--- a/cytoolz/itertoolz.pxd
+++ b/cytoolz/itertoolz.pxd
@@ -94,6 +94,9 @@ cpdef object get(object ind, object seq, object default=*)
 cpdef object cons(object el, object seq)
 
 
+cpdef object concat(object seqs)
+
+
 cpdef object mapcat(object func, object seqs)
 
 

--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -27,10 +27,6 @@ __all__ = ['remove', 'accumulate', 'groupby', 'merge_sorted', 'interleave',
            'join', 'tail', 'diff', 'topk', 'peek', 'random_sample']
 
 
-concatv = chain
-concat = chain.from_iterable
-
-
 cpdef object identity(object x):
     return x
 
@@ -695,6 +691,38 @@ cpdef object get(object ind, object seq, object default='__no__default__'):
     return <object>obj
 
 
+cpdef object concat(object seqs):
+    """
+    Concatenate zero or more iterables, any of which may be infinite.
+
+    An infinite sequence will prevent the rest of the arguments from
+    being included.
+
+    We use chain.from_iterable rather than ``chain(*seqs)`` so that seqs
+    can be a generator.
+
+    >>> list(concat([[], [1], [2, 3]]))
+    [1, 2, 3]
+
+    See also:
+        itertools.chain.from_iterable  equivalent
+    """
+    return chain.from_iterable(seqs)
+
+
+def concatv(*seqs):
+    """
+    Variadic version of concat
+
+    >>> list(concatv([], ["a"], ["b", "c"]))
+    ['a', 'b', 'c']
+
+    See also:
+        itertools.chain
+    """
+    return chain.from_iterable(seqs)
+
+
 cpdef object mapcat(object func, object seqs):
     """
     Apply func to each sequence in seqs, concatenating results.
@@ -1145,8 +1173,7 @@ cpdef object pluck(object ind, object seqs, object default='__no__default__'):
 
     This is equivalent to running `map(curried.get(ind), seqs)`
 
-    ``ind`` can be either a single string/index or a sequence of
-    strings/indices.
+    ``ind`` can be either a single string/index or a list of strings/indices.
     ``seqs`` should be sequence containing sequences or dicts.
 
     e.g.

--- a/cytoolz/tests/test_curried.py
+++ b/cytoolz/tests/test_curried.py
@@ -2,6 +2,7 @@ import cytoolz
 import cytoolz.curried
 from cytoolz.curried import (take, first, second, sorted, merge_with, reduce,
                            merge, operator as cop)
+from cytoolz.compatibility import import_module
 from collections import defaultdict
 from operator import add
 
@@ -62,3 +63,51 @@ def test_curried_operator():
 
     # Make sure this isn't totally empty.
     assert len(set(vars(cop)) & set(['add', 'sub', 'mul'])) == 3
+
+
+def test_curried_namespace():
+    exceptions = import_module('cytoolz.curried.exceptions')
+    namespace = {}
+
+    def should_curry(func):
+        if not callable(func) or isinstance(func, cytoolz.curry):
+            return False
+        nargs = cytoolz.functoolz.num_required_args(func)
+        if nargs is None or nargs > 1:
+            return True
+        return nargs == 1 and cytoolz.functoolz.has_keywords(func)
+
+
+    def curry_namespace(ns):
+        return dict(
+            (name, cytoolz.curry(f) if should_curry(f) else f)
+            for name, f in ns.items() if '__' not in name
+        )
+
+    from_cytoolz = curry_namespace(vars(cytoolz))
+    from_exceptions = curry_namespace(vars(exceptions))
+    namespace.update(cytoolz.merge(from_cytoolz, from_exceptions))
+
+    namespace = cytoolz.valfilter(callable, namespace)
+    curried_namespace = cytoolz.valfilter(callable, cytoolz.curried.__dict__)
+
+    if namespace != curried_namespace:
+        missing = set(namespace) - set(curried_namespace)
+        if missing:
+            raise AssertionError('There are missing functions in cytoolz.curried:\n    %s'
+                                 % '    \n'.join(sorted(missing)))
+        extra = set(curried_namespace) - set(namespace)
+        if extra:
+            raise AssertionError('There are extra functions in cytoolz.curried:\n    %s'
+                                 % '    \n'.join(sorted(extra)))
+        unequal = cytoolz.merge_with(list, namespace, curried_namespace)
+        unequal = cytoolz.valfilter(lambda x: x[0] != x[1], unequal)
+        messages = []
+        for name, (orig_func, auto_func) in sorted(unequal.items()):
+            if name in from_exceptions:
+                messages.append('%s should come from cytoolz.curried.exceptions' % name)
+            elif should_curry(getattr(cytoolz, name)):
+                messages.append('%s should be curried from cytoolz' % name)
+            else:
+                messages.append('%s should come from cytoolz and NOT be curried' % name)
+        raise AssertionError('\n'.join(messages))

--- a/cytoolz/tests/test_docstrings.py
+++ b/cytoolz/tests/test_docstrings.py
@@ -15,7 +15,7 @@ skipped_doctests = ['get_in']
 @curry
 def isfrommod(modname, func):
     mod = getattr(func, '__module__', '') or ''
-    return modname in mod
+    return mod.startswith(modname) or 'toolz.functoolz.curry' in str(type(func))
 
 
 def convertdoc(doc):

--- a/cytoolz/tests/test_itertoolz.py
+++ b/cytoolz/tests/test_itertoolz.py
@@ -86,6 +86,13 @@ def test_merge_sorted():
             [(9, 1), (9, 8), (9, 9)]]
     assert list(merge_sorted(*data, key=lambda x: x[1])) == [
         (9, 1), (1, 2), (5, 3), (0, 4), (6, 5), (3, 6), (8, 8), (9, 8), (9, 9)]
+    assert list(merge_sorted()) == []
+    assert list(merge_sorted([1, 2, 3])) == [1, 2, 3]
+    assert list(merge_sorted([1, 4, 5], [2, 3])) == [1, 2, 3, 4, 5]
+    assert list(merge_sorted([1, 4, 5], [2, 3], key=identity)) == [
+        1, 2, 3, 4, 5]
+    assert list(merge_sorted([1, 5], [2], [4, 7], [3, 6], key=identity)) == [
+        1, 2, 3, 4, 5, 6, 7]
 
 
 def test_interleave():

--- a/cytoolz/tests/test_serialization.py
+++ b/cytoolz/tests/test_serialization.py
@@ -40,3 +40,18 @@ def test_instanceproperty():
     assert p2.__get__(None) is None
     assert p2.__get__(0) is False
     assert p2.__get__(1) is True
+
+
+def f(x, y):
+    return x, y
+
+
+def test_flip():
+    flip = pickle.loads(pickle.dumps(cytoolz.functoolz.flip))
+    assert flip is cytoolz.functoolz.flip
+    g1 = flip(f)
+    g2 = pickle.loads(pickle.dumps(g1))
+    assert g1(1, 2) == g2(1, 2) == f(2, 1)
+    g1 = flip(f)(1)
+    g2 = pickle.loads(pickle.dumps(g1))
+    assert g1(2) == g2(2) == f(2, 1)


### PR DESCRIPTION
1. `memoize` and `flip` are curried now, and `c_memoize` and `c_flip` were removed.
2. Update doctest of `flip`.
3. Improved pickling of curried objects in top-level modules.
4. Added `_should_curry` (even though it's an implementation detail atm) to `curry`.
5. `pass_exceptions=` keyword removed from `interleave`.
6. Updated tests and `toolz.curried` via make commands.