### PR TITLE
Fix #104.  Be more careful when getting references without the Cython refnanny!

### DIFF
--- a/cytoolz/itertoolz.pyx
+++ b/cytoolz/itertoolz.pyx
@@ -687,8 +687,9 @@ cpdef object get(object ind, object seq, object default='__no__default__'):
         if PyErr_GivenExceptionMatches(val, _get_exceptions):
             return default
         raise val
+    val = <object>obj
     Py_XDECREF(obj)
-    return <object>obj
+    return val
 
 
 cpdef object concat(object seqs):
@@ -1107,8 +1108,9 @@ cdef class _pluck_index_default:
             if not PyErr_GivenExceptionMatches(val, _get_exceptions):
                 raise val
             return self.default
+        val = <object>obj
         Py_XDECREF(obj)
-        return <object>obj
+        return val
 
 
 cdef class _pluck_list:

--- a/cytoolz/tests/test_inspect_args.py
+++ b/cytoolz/tests/test_inspect_args.py
@@ -409,6 +409,8 @@ def test_introspect_builtin_modules():
     def is_missing(modname, name, func):
         if name.startswith('_') and not name.startswith('__'):
             return False
+        if name.startswith('__pyx_unpickle_') or name.endswith('_cython__'):
+            return False
         try:
             if issubclass(func, BaseException):
                 return False


### PR DESCRIPTION
Notably, `get` would fail when the gotten object had exactly 1 reference count.  This is actually uncommon in Python, but it can happen in Numpy (or when Python objects are managed in C).