### PR TITLE
Fix #101.  Modify how we handle curried `memoize` to make `cimport cytoolz work again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ script:
     # For convenience, make sure simple test commands work
     - py.test
     - nosetests
+    # Make sure we can cimport cytoolz
+    - echo 'cimport cytoolz ; from cytoolz.functoolz cimport memoize' > try_cimport_cytoolz.pyx
+    - cythonize -i try_cimport_cytoolz.pyx
+    - python -c 'import try_cimport_cytoolz'
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ inplace:
 
 test: inplace
 	nosetests -s --with-doctest cytoolz/
+	echo 'cimport cytoolz ; from cytoolz.functoolz cimport memoize' > try_cimport_cytoolz.pyx
+	cythonize -i try_cimport_cytoolz.pyx
+	python -c 'import try_cimport_cytoolz'
+	rm try_cimport_cytoolz.pyx
 
 clean:
 	rm -f cytoolz/*.c cytoolz/*.so cytoolz/*/*.c cytoolz/*/*.so

--- a/cytoolz/functoolz.pxd
+++ b/cytoolz/functoolz.pxd
@@ -18,7 +18,11 @@ cdef class curry:
     cdef public object __module__
     cdef public object __qualname__
 
-cdef class memoize:
+
+cpdef object memoize(object func, object cache=*, object key=*)
+
+
+cdef class _memoize:
     cdef object func
     cdef object cache
     cdef object key

--- a/cytoolz/functoolz.pyx
+++ b/cytoolz/functoolz.pyx
@@ -376,9 +376,8 @@ cpdef object _restore_curry(cls, func, args, kwargs, is_decorated):
     return obj
 
 
-cdef class memoize:
-    """ memoize(func, cache=None, key=None)
-
+cpdef object memoize(object func, object cache=None, object key=None):
+    """
     Cache a function's result for speedy future evaluation
 
     Considerations:
@@ -414,6 +413,10 @@ cdef class memoize:
     ...         print('Calculating %s + %s' % (x, y))
     ...     return x + y
     """
+    return _memoize(func, cache, key)
+
+
+cdef class _memoize:
 
     property __doc__:
         def __get__(self):
@@ -427,7 +430,7 @@ cdef class memoize:
         def __get__(self):
             return self.func
 
-    def __cinit__(self, func, cache=None, key=None):
+    def __cinit__(self, func, cache, key):
         self.func = func
         if cache is None:
             self.cache = PyDict_New()
@@ -466,9 +469,6 @@ cdef class memoize:
         if instance is None:
             return self
         return curry(self, instance)
-
-
-_memoize = memoize  # uncurried
 
 
 cdef class Compose:


### PR DESCRIPTION
Also added a test to make sure we can cimport cytoolz.