### PR TITLE
test python 3.7 in travi-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7-dev"
 
 before_install:
     - pip install git+https://github.com/pytoolz/toolz.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ python:
     - "3.6"
     - "3.7-dev"
 
+matrix:
+    allow_failures:
+        - python: "3.7-dev"
+
 before_install:
     - pip install git+https://github.com/pytoolz/toolz.git
     - pip install cython pytest


### PR DESCRIPTION
Currently the dev version, `"3.7-dev"`, since Python 3.7.0 isn't due to be released until 2018-06-15.