### PR TITLE
Update README.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: inplace
 	echo 'cimport cytoolz ; from cytoolz.functoolz cimport memoize' > try_cimport_cytoolz.pyx
 	cythonize -i try_cimport_cytoolz.pyx
 	python -c 'import try_cimport_cytoolz'
-	rm try_cimport_cytoolz.pyx
+	rm try_cimport_cytoolz.*
 
 clean:
 	rm -f cytoolz/*.c cytoolz/*.so cytoolz/*/*.c cytoolz/*/*.so

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 CyToolz
 =======
 
-|Build Status| |Version Status| |Downloads|
+|Build Status| |Version Status|
 
 Cython implementation of the
 |literal toolz|_ `package, <https://pypi.python.org/pypi/toolz/>`__ which
@@ -48,7 +48,7 @@ Install
 Dependencies
 ------------
 
-``cytoolz`` supports Python 2.6+ and Python 3.2+ with a common codebase.
+``cytoolz`` supports Python 2.6+ and Python 3.3+ with a common codebase.
 It is developed in Cython, but requires no dependecies other than CPython
 and a C compiler.  Like ``toolz``, it is a light weight dependency.
 
@@ -76,5 +76,3 @@ We're friendly.
    :target: https://travis-ci.org/pytoolz/cytoolz
 .. |Version Status| image:: https://badge.fury.io/py/cytoolz.svg
    :target: http://badge.fury.io/py/cytoolz
-.. |Downloads| image:: https://img.shields.io/pypi/dm/cytoolz.svg
-   :target: https://pypi.python.org/pypi/cytoolz/


### PR DESCRIPTION
PyPI no longer provides download count badge.
Also, Python 3.3 is the minimum version of Python 3 we test and support.