### PR TITLE
Test Python 3.8 (#136) and use Cython if available (#134)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,8 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7-dev"
-
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-    include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+    - "3.7"
+    - "3.8"
 
 before_install:
     - pip install git+https://github.com/pytoolz/toolz.git

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,17 @@ Pass "--no-cython" or "--without-cython" to disable usage of Cython.
 For convenience, developmental versions (with 'dev' in the version number)
 automatically use Cython unless disabled via a command line argument.
 
+To summarize differently, the rules are as follows (apply first applicable rule):
+
+  1. If `--no-cython` or `--without-cython` are used, then only build from `.*c` files.
+  2. If this is a dev version, then cythonize only the files that have changed.
+  3. If `--cython` or `--with-cython` are used, then force cythonize all files.
+  4. If no arguments are passed, then force cythonize all files if Cython is available,
+     else build from `*.c` files.  This is default when installing via pip.
+
+By forcing cythonization of all files (except in dev) if Cython is available,
+we avoid the case where the generated `*.c` files are not forward-compatible.
+
 """
 import os.path
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 """ Build ``cytoolz`` with or without Cython.
 
-Deployed versions of CyToolz do not rely on Cython by default even if the
-user has Cython installed.  A C compiler is used to compile the distributed
-*.c files instead.
+By default, CyToolz will be built using Cython if available.
+If Cython is not available, then the default C compiler will be used
+to compile the distributed *.c files instead.
 
-Pass "--cython" or "--with-cython" as a command line argument to setup.py
-to build the project using Cython.
+Pass "--cython" or "--with-cython" as a command line argument to setup.py to
+force the project to build using Cython (and fail if Cython is unavailable).
 
 Pass "--no-cython" or "--without-cython" to disable usage of Cython.
 
@@ -29,8 +29,8 @@ try:
 except ImportError:
     has_cython = False
 
-is_dev = 'dev' in VERSION
-use_cython = is_dev or '--cython' in sys.argv or '--with-cython' in sys.argv
+use_cython = True
+force_cython = 'dev' in VERSION
 if '--no-cython' in sys.argv:
     use_cython = False
     sys.argv.remove('--no-cython')
@@ -38,14 +38,16 @@ if '--without-cython' in sys.argv:
     use_cython = False
     sys.argv.remove('--without-cython')
 if '--cython' in sys.argv:
+    force_cython = True
     sys.argv.remove('--cython')
 if '--with-cython' in sys.argv:
+    force_cython = True
     sys.argv.remove('--with-cython')
 
 if use_cython and not has_cython:
-    if is_dev:
+    if force_cython:
         raise RuntimeError('Cython required to build dev version of cytoolz.')
-    print('WARNING: Cython not installed.  Building without Cython.')
+    print('ALERT: Cython not installed.  Building without Cython.')
     use_cython = False
 
 if use_cython:
@@ -67,6 +69,7 @@ if use_cython:
         from Cython.Compiler.Options import directive_defaults
     directive_defaults['embedsignature'] = True
     directive_defaults['binding'] = True
+    directive_defaults['language_level'] = 2  # TODO: drop Python 2.7 and update this (and code) to 3
     ext_modules = cythonize(ext_modules)
 
 setup(
@@ -105,6 +108,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: Software Development',
@@ -113,5 +117,6 @@ setup(
         'Topic :: Utilities',
     ],
     install_requires=['toolz >= 0.8.0'],
+    extras_require={'cython': ['cython']},
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ except ImportError:
     has_cython = False
 
 use_cython = True
-force_cython = 'dev' in VERSION
+is_dev = 'dev' in VERSION
+strict_cython = is_dev
 if '--no-cython' in sys.argv:
     use_cython = False
     sys.argv.remove('--no-cython')
@@ -38,14 +39,14 @@ if '--without-cython' in sys.argv:
     use_cython = False
     sys.argv.remove('--without-cython')
 if '--cython' in sys.argv:
-    force_cython = True
+    strict_cython = True
     sys.argv.remove('--cython')
 if '--with-cython' in sys.argv:
-    force_cython = True
+    strict_cython = True
     sys.argv.remove('--with-cython')
 
 if use_cython and not has_cython:
-    if force_cython:
+    if strict_cython:
         raise RuntimeError('Cython required to build dev version of cytoolz.')
     print('ALERT: Cython not installed.  Building without Cython.')
     use_cython = False
@@ -70,7 +71,9 @@ if use_cython:
     directive_defaults['embedsignature'] = True
     directive_defaults['binding'] = True
     directive_defaults['language_level'] = 2  # TODO: drop Python 2.7 and update this (and code) to 3
-    ext_modules = cythonize(ext_modules)
+    # The distributed *.c files may not be forward compatible.
+    # If we are cythonizing a non-dev version, then force everything to cythonize.
+    ext_modules = cythonize(ext_modules, force=not is_dev)
 
 setup(
     name='cytoolz',


### PR DESCRIPTION
Python 3.8 failed to install cytoolz b/c the .c files created by Cython were not forward-compatible.  This justifies always using Cython if available.

Also, add Cython as an optional dependency via `extras_require` in setup.py.  This should allow `pip install "cytoolz[cython]"` to do the right thing.