### PR TITLE
Update to latest toolz: make juxt a class with .funcs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,7 +1,7 @@
 name: Build wheels
 
 on:
-  pull_request:
+  # pull_request:  # Uncomment to debug wheel building in a PR
   push:
     branches:
       - master

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,10 +24,13 @@ jobs:
           # # Archs: https://cibuildwheel.readthedocs.io/en/stable/options/#archs
           # # This probably isn't the preferred way to do things :shrug:
           #
+          # # PyPy may have issues.  Intermittent failures have been seen on:
+          # # pp37-manylinux_aarch64 pp38-win_amd64
+          #
           # pys = ['cp36', 'cp37', 'cp38', 'cp39', 'cp310']
           # pys_arm = ['cp38', 'cp39', 'cp310']
           # pypys = ['pp37', 'pp38', 'pp39']
-          # SKIP = {"pp37-manylinux_aarch64"}
+          # SKIP = set()  # {"pp37-manylinux_aarch64", "pp38-win_amd64"}
           # combos = []
           #
           # # Linux
@@ -121,8 +124,8 @@ jobs:
           - {"os": "ubuntu", "build": "cp310-musllinux_ppc64le", "arch": "ppc64le"}
           - {"os": "ubuntu", "build": "cp310-musllinux_s390x", "arch": "s390x"}
           - {"os": "ubuntu", "build": "cp310-musllinux_x86_64", "arch": "x86_64"}
-          # Segfault in test_dicttoolz.py:test_merge_with
-          # - {"os": "ubuntu", "build": "pp37-manylinux_aarch64", "arch": "aarch64"}
+          # Intermittent segfault on pp37-manylinux_aarch64 in test_dicttoolz.py:test_merge_with
+          - {"os": "ubuntu", "build": "pp37-manylinux_aarch64", "arch": "aarch64"}
           - {"os": "ubuntu", "build": "pp37-manylinux_i686", "arch": "i686"}
           - {"os": "ubuntu", "build": "pp37-manylinux_x86_64", "arch": "x86_64"}
           - {"os": "ubuntu", "build": "pp38-manylinux_aarch64", "arch": "aarch64"}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,7 @@
 name: Build wheels
 
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -189,9 +190,7 @@ jobs:
         with:
           python-version: "3.8"
       - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install setuptools wheel cython
+        run: python -m pip install setuptools wheel cython
       - name: Build sdist
         run: python setup.py sdist
       - name: Upload sdist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -190,7 +190,9 @@ jobs:
         with:
           python-version: "3.8"
       - name: Install build dependencies
-        run: python -m pip install setuptools wheel cython
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools wheel cython
       - name: Build sdist
         run: python setup.py sdist
       - name: Upload sdist

--- a/cytoolz/__init__.pxd
+++ b/cytoolz/__init__.pxd
@@ -7,7 +7,7 @@ from cytoolz.itertoolz cimport (
 
 
 from cytoolz.functoolz cimport (
-    c_compose, c_juxt, memoize, c_pipe, c_thread_first, c_thread_last,
+    c_compose, memoize, c_pipe, c_thread_first, c_thread_last,
     complement, curry, do, identity, excepts, flip)
 
 

--- a/cytoolz/__init__.py
+++ b/cytoolz/__init__.py
@@ -23,5 +23,10 @@ from . import curried  # sandbox
 
 functoolz._sigs.update_signature_registry()
 
-from ._version import __version__, __toolz_version__
+# What version of toolz does cytoolz implement?
+__toolz_version__ = '0.12.0'
 
+from ._version import get_versions
+
+__version__ = get_versions()['version']
+del get_versions

--- a/cytoolz/_version.py
+++ b/cytoolz/_version.py
@@ -18,10 +18,6 @@ import sys
 import functools
 
 
-# What version of toolz does cytoolz implement?  Placed here compatibility.
-__toolz_version__ = '0.12.0'
-
-
 def get_keywords():
     """Get the keywords needed to look up the version information."""
     # these strings will be replaced by git during git-archive.
@@ -659,6 +655,3 @@ def get_versions():
     return {"version": "0+unknown", "full-revisionid": None,
             "dirty": None,
             "error": "unable to compute version", "date": None}
-
-
-__version__ = get_versions()['version']

--- a/cytoolz/functoolz.pxd
+++ b/cytoolz/functoolz.pxd
@@ -48,11 +48,8 @@ cdef class complement:
     cdef object func
 
 
-cdef class _juxt_inner:
+cdef class juxt:
     cdef public tuple funcs
-
-
-cdef object c_juxt(object funcs)
 
 
 cpdef object do(object func, object x)


### PR DESCRIPTION
This drops `c_juxt` C-only function, which no longer confers any benefit over using `juxt` directly.  Does anybody even use `cimport` from `cytoolz`?