### PR TITLE
Build wheels for Python 3.11

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,7 +1,7 @@
 name: Build wheels
 
 on:
-  # pull_request:  # Uncomment to debug wheel building in a PR
+  pull_request:  # Uncomment to debug wheel building in a PR
   push:
     branches:
       - master
@@ -27,8 +27,8 @@ jobs:
           # # PyPy may have issues.  Intermittent failures have been seen on:
           # # pp37-manylinux_aarch64 pp38-win_amd64
           #
-          # pys = ['cp36', 'cp37', 'cp38', 'cp39', 'cp310']
-          # pys_arm = ['cp38', 'cp39', 'cp310']
+          # pys = ['cp36', 'cp37', 'cp38', 'cp39', 'cp310', 'cp311']
+          # pys_arm = ['cp38', 'cp39', 'cp310', 'cp311']
           # pypys = ['pp37', 'pp38', 'pp39']
           # SKIP = set()  # {"pp37-manylinux_aarch64", "pp38-win_amd64"}
           # combos = []
@@ -60,7 +60,7 @@ jobs:
           #     combos.append(('windows', f'{py}-win_amd64', 'AMD64'))
           #
           # # Sort, filter, and print combinations
-          # for os, build, arch in sorted(combos, key=lambda x: (x[0], x[1].replace('310', '390'), x[2])):
+          # for os, build, arch in sorted(combos, key=lambda x: (x[0], x[1].replace('310', '390').replace('311', '391'), x[2])):
           #     skip = "# " if build in SKIP else ""
           #     print(f'        {skip}- {{"os": "{os}", "build": "{build}", "arch": "{arch}"}}')
           - {"os": "macos", "build": "cp36-macosx_x86_64", "arch": "x86_64"}
@@ -71,6 +71,8 @@ jobs:
           - {"os": "macos", "build": "cp39-macosx_x86_64", "arch": "x86_64"}
           - {"os": "macos", "build": "cp310-macosx_arm64", "arch": "arm64"}
           - {"os": "macos", "build": "cp310-macosx_x86_64", "arch": "x86_64"}
+          - {"os": "macos", "build": "cp311-macosx_arm64", "arch": "arm64"}
+          - {"os": "macos", "build": "cp311-macosx_x86_64", "arch": "x86_64"}
           - {"os": "macos", "build": "pp37-macosx_x86_64", "arch": "x86_64"}
           - {"os": "macos", "build": "pp38-macosx_x86_64", "arch": "x86_64"}
           - {"os": "macos", "build": "pp39-macosx_x86_64", "arch": "x86_64"}
@@ -124,6 +126,16 @@ jobs:
           - {"os": "ubuntu", "build": "cp310-musllinux_ppc64le", "arch": "ppc64le"}
           - {"os": "ubuntu", "build": "cp310-musllinux_s390x", "arch": "s390x"}
           - {"os": "ubuntu", "build": "cp310-musllinux_x86_64", "arch": "x86_64"}
+          - {"os": "ubuntu", "build": "cp311-manylinux_aarch64", "arch": "aarch64"}
+          - {"os": "ubuntu", "build": "cp311-manylinux_i686", "arch": "i686"}
+          - {"os": "ubuntu", "build": "cp311-manylinux_ppc64le", "arch": "ppc64le"}
+          - {"os": "ubuntu", "build": "cp311-manylinux_s390x", "arch": "s390x"}
+          - {"os": "ubuntu", "build": "cp311-manylinux_x86_64", "arch": "x86_64"}
+          - {"os": "ubuntu", "build": "cp311-musllinux_aarch64", "arch": "aarch64"}
+          - {"os": "ubuntu", "build": "cp311-musllinux_i686", "arch": "i686"}
+          - {"os": "ubuntu", "build": "cp311-musllinux_ppc64le", "arch": "ppc64le"}
+          - {"os": "ubuntu", "build": "cp311-musllinux_s390x", "arch": "s390x"}
+          - {"os": "ubuntu", "build": "cp311-musllinux_x86_64", "arch": "x86_64"}
           # Intermittent segfault on pp37-manylinux_aarch64 in test_dicttoolz.py:test_merge_with
           - {"os": "ubuntu", "build": "pp37-manylinux_aarch64", "arch": "aarch64"}
           - {"os": "ubuntu", "build": "pp37-manylinux_i686", "arch": "i686"}
@@ -144,6 +156,8 @@ jobs:
           - {"os": "windows", "build": "cp39-win_amd64", "arch": "AMD64"}
           - {"os": "windows", "build": "cp310-win32", "arch": "x86"}
           - {"os": "windows", "build": "cp310-win_amd64", "arch": "AMD64"}
+          - {"os": "windows", "build": "cp311-win32", "arch": "x86"}
+          - {"os": "windows", "build": "cp311-win_amd64", "arch": "AMD64"}
           - {"os": "windows", "build": "pp37-win_amd64", "arch": "AMD64"}
           - {"os": "windows", "build": "pp38-win_amd64", "arch": "AMD64"}
           - {"os": "windows", "build": "pp39-win_amd64", "arch": "AMD64"}
@@ -163,7 +177,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.1
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,7 +1,7 @@
 name: Build wheels
 
 on:
-  pull_request:  # Uncomment to debug wheel building in a PR
+  # pull_request:  # Uncomment to debug wheel building in a PR
   push:
     branches:
       - master


### PR DESCRIPTION
Build wheels for Python 3.11 via cibuildwheel.

Still skipping `win_arm64` for now.