### PR TITLE
Improve flip to accept *args and kwargs

### DIFF
--- a/cytoolz/_signatures.py
+++ b/cytoolz/_signatures.py
@@ -54,9 +54,10 @@ cytoolz_info['cytoolz.functoolz'] = dict(
         lambda: None,
         lambda func: None,
         lambda func, a: None,
-        lambda func, a, b: None],
+        lambda func, a, b: None,
+        lambda func, *args, **kwargs: None],
     _flip=[
-        lambda func, a, b: None],
+        lambda func, *args, **kwargs: None],
     identity=[
         lambda x: None],
     juxt=[

--- a/cytoolz/functoolz.pxd
+++ b/cytoolz/functoolz.pxd
@@ -55,7 +55,7 @@ cdef class juxt:
 cpdef object do(object func, object x)
 
 
-cpdef object flip(object func, object a, object b)
+cpdef object c_flip(object func, tuple args, dict kwargs)
 
 
 cpdef object return_none(object exc)

--- a/cytoolz/functoolz.pyx
+++ b/cytoolz/functoolz.pyx
@@ -751,7 +751,11 @@ cpdef object do(object func, object x):
     return x
 
 
-cpdef object flip(object func, object a, object b):
+cpdef object c_flip(object func, tuple args, dict kwargs):
+    return PyObject_Call(func, tuple(reversed(args)), kwargs)
+
+
+def flip(func, *args, **kwargs):
     """
     Call the function call with the arguments flipped
 
@@ -775,7 +779,7 @@ cpdef object flip(object func, object a, object b):
     >>> only_ints
     [1, 2, 3]
     """
-    return PyObject_CallObject(func, (b, a))
+    return c_flip(func, args, kwargs)
 
 
 _flip = flip  # uncurried

--- a/cytoolz/tests/test_functoolz.py
+++ b/cytoolz/tests/test_functoolz.py
@@ -735,6 +735,13 @@ def test_flip():
     assert flip(f, 'a', 'b') == ('b', 'a')
 
 
+def test_flip_args_kwargs():
+    def g(a, b, c, *, d, e):
+        return a, b, c, d, e
+
+    assert flip(g, 3, 2, 1, d=4, e=5) == (1, 2, 3, 4, 5)
+
+
 def test_excepts():
     # These are descriptors, make sure this works correctly.
     assert excepts.__name__ == 'excepts'


### PR DESCRIPTION
This PR mirrors a PR in toolz: https://github.com/pytoolz/toolz/pull/566

As stated in that PR:
First, thanks for the great project!

Currently, flip is limited to two arguments, and it does not handle keyword arguments.
I might be missing something, but this seems easy to fix, and should be a non-breaking change.

Let me know if any other changes are needed.