### PR TITLE
Skip `pyodide` upload, since it's not yet supported by PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,6 +65,7 @@ jobs:
             platform: ios
             archs: all
           - os: pyodide
+            # pyodide is not yet supported by PyPI, but let's make sure we can build for it
             runs-on: ubuntu-latest
             platform: pyodide
             archs: all
@@ -96,6 +97,7 @@ jobs:
         run: |
           ls -al wheelhouse/
       - name: Upload wheels
+        if: matrix.platform != 'pyodide'  # pyodide is not yet supported by PyPI
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}


### PR DESCRIPTION
But, let's continue to build pyodide wheels so we'll be ready for when they're usable

(I think we're almost ready to release)